### PR TITLE
A quick tweak to make the editor tree state configurable

### DIFF
--- a/editor/settings.py
+++ b/editor/settings.py
@@ -7,3 +7,5 @@ STATIC_URL = getattr(settings, 'STATIC_URL', settings.MEDIA_URL)
 if STATIC_URL == None:
     STATIC_URL = settings.MEDIA_URL
 MEDIA_PATH = getattr(settings, 'EDITOR_MEDIA_PATH', '%seditor/' % STATIC_URL)
+
+TREE_INITIAL_STATE = getattr(settings, 'EDITOR_TREE_INITIAL_STATE', 'collapsed')

--- a/editor/templates/admin/editor/tree_editor.html
+++ b/editor/templates/admin/editor/tree_editor.html
@@ -5,8 +5,7 @@
 	<script type="text/javascript">
 	(function($) {
 		$(document).ready(function()  {
-		//treeTable = $("#result_list").treeTable({initialState : "expanded"});
-		treeTable = $("#result_list").treeTable({initialState : "collapsed"});
+		treeTable = $("#result_list").treeTable({initialState : "{{ EDITOR_TREE_INITIAL_STATE }}"});
 		function toggleChildren() {
 			this.checked = event.currentTarget.checked;
 			var row = this.parentNode.parentNode.parentNode;

--- a/editor/tree_editor.py
+++ b/editor/tree_editor.py
@@ -77,6 +77,7 @@ class TreeEditor(admin.ModelAdmin):
         """
         extra_context = extra_context or {}
         extra_context['EDITOR_MEDIA_PATH'] = settings.MEDIA_PATH
+        extra_context['EDITOR_TREE_INITIAL_STATE'] = settings.TREE_INITIAL_STATE
         extra_context['tree_structure'] = mark_safe(simplejson.dumps(
                                                     _build_tree_structure(self.model)))
 


### PR DESCRIPTION
I'm flexible on the name and such, but this makes things a little nicer for those of us who don't have large enough trees to cause a performance issue.
