### PR TITLE
Missing queryset parameter on get_ordering() for TreeChangeList

### DIFF
--- a/categories/editor/tree_editor.py
+++ b/categories/editor/tree_editor.py
@@ -72,7 +72,7 @@ class TreeChangeList(ChangeList):
         else:
             return []
     
-    def get_ordering(self, request=None):
+    def get_ordering(self, request=None, queryset=None):
         if django.VERSION[1] < 4:
             return '', '' #('tree_id', 'lft')
         else:


### PR DESCRIPTION
Using Django v1.4c2 I get an error in the admin about this missing parameter.
