### PR TITLE
Error with the last south (0.7.4)

### DIFF
--- a/categories/migrations/0010_add_field_categoryrelation_category.py
+++ b/categories/migrations/0010_add_field_categoryrelation_category.py
@@ -7,9 +7,6 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        # Changing field 'Category.parent'
-        db.alter_column('categories_category', 'parent_id', self.gf('mptt.fields.TreeForeignKey')(null=True, to=orm['categories.Category']))
-
         # Changing field 'Category.order'
         db.alter_column('categories_category', 'order', self.gf('django.db.models.fields.IntegerField')())
 


### PR DESCRIPTION
If you removed this line the db schema is the same and the migrations works. With this line raise a error:

FATAL ERROR - The following SQL query failed: ALTER TABLE "categories_category" ADD CONSTRAINT "parent_id_refs_id_17a07b95" FOREIGN KEY ("parent_id") REFERENCES "categories_category" ("id") DEFERRABLE INITIALLY DEFERRED;

I test this in postgres sql
