### PR TITLE
Using ugettext_lazy

### DIFF
--- a/categories/models.py
+++ b/categories/models.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.core.files.storage import get_storage_class
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .settings import (RELATION_MODELS, RELATIONS, THUMBNAIL_UPLOAD_PATH, 
                         THUMBNAIL_STORAGE)

--- a/categories/views.py
+++ b/categories/views.py
@@ -5,7 +5,7 @@ from django.template import RequestContext
 from django.http import HttpResponse, Http404
 from django.views.decorators.cache import cache_page
 from django.template.loader import select_template
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .models import Category
 from .settings import CACHE_VIEW_LENGTH


### PR DESCRIPTION
Hi,

I've changed use of ugettext to ugettext_lazy as it was indirectly causing a circular import error in a project of mine (django-haystack is the real culprit, but this way it could be solved).

It was already used in one of three locations in the code that use ugettext, so I figured it wouldn't matter.
