### PR TITLE
make Category registration in admin optional

### DIFF
--- a/categories/admin.py
+++ b/categories/admin.py
@@ -1,9 +1,8 @@
 from django.contrib import admin
-from django.conf import settings
 from django import forms
 
 from .genericcollection import GenericCollectionTabularInline
-from .settings import RELATION_MODELS, JAVASCRIPT_URL
+from .settings import RELATION_MODELS, JAVASCRIPT_URL, REGISTER_ADMIN
 from .models import Category
 from .base import CategoryBaseAdminForm, CategoryBaseAdmin
 
@@ -65,7 +64,7 @@ class CategoryAdmin(CategoryBaseAdmin):
     class Media:
         js = (JAVASCRIPT_URL + 'genericcollections.js',)
 
-if getattr(settings, 'REGISTER_CATEGORY_MODEL_IN_ADMIN', True):
+if REGISTER_ADMIN:
     admin.site.register(Category, CategoryAdmin)
 
 for model, modeladmin in admin.site._registry.items():

--- a/categories/settings.py
+++ b/categories/settings.py
@@ -13,6 +13,7 @@ DEFAULT_SETTINGS = {
     'THUMBNAIL_STORAGE': settings.DEFAULT_FILE_STORAGE,
     'JAVASCRIPT_URL': getattr(settings, 'STATIC_URL', settings.MEDIA_URL) + 'js/',
     'SLUG_TRANSLITERATOR': '',
+    'REGISTER_ADMIN': True,
 }
 
 DEFAULT_SETTINGS.update(getattr(settings, 'CATEGORIES_SETTINGS', {}))

--- a/doc_src/reference/settings.rst
+++ b/doc_src/reference/settings.rst
@@ -85,6 +85,16 @@ FK_REGISTRY
 
 .. _THUMBNAIL_UPLOAD_PATH:
 
+.. _REGISTER_ADMIN:
+
+REGISTER_ADMIN
+==============
+
+**Default:** ``True``
+
+**Description:** If you write your own category class by subclassing ``CategoryBase`` then you probably have no use for registering the default ``Category`` class in the admin.
+
+
 THUMBNAIL_UPLOAD_PATH
 =====================
 


### PR DESCRIPTION
I don't know if this is exactly how you want to do this, but it would be nice to have a config option that allows you to not register Category in the admin for cases when you just subclass CategoryBase and never use the shipped model.
