### PR TITLE
1.5 compat: remove adminmedia templatetag calls

### DIFF
--- a/categories/editor/templates/admin/editor/grappelli_tree_editor.html
+++ b/categories/editor/templates/admin/editor/grappelli_tree_editor.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load adminmedia admin_list i18n admin_tree_list %}
+{% load admin_list i18n admin_tree_list %}
 {% block extrahead %}
     {{block.super}}
     <script type="text/javascript">

--- a/categories/editor/templates/admin/editor/tree_editor.html
+++ b/categories/editor/templates/admin/editor/tree_editor.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load adminmedia admin_list i18n admin_tree_list %}
+{% load admin_list i18n admin_tree_list %}
 {% block extrahead %}
     {{block.super}}
     <script type="text/javascript">

--- a/categories/templates/admin/edit_inline/gen_coll_tabular.html
+++ b/categories/templates/admin/edit_inline/gen_coll_tabular.html
@@ -1,4 +1,4 @@
-{% load i18n adminmedia %}
+{% load i18n staticfiles %}
 <div class="inline-group">
 	<div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 		{{ inline_admin_formset.formset.management_form }}
@@ -46,7 +46,7 @@
 											{% ifequal field.field.name inline_admin_formset.formset.ct_fk_field %}
 												{{ field.field }} 
 												<a id="lookup_id_{{field.field.html_name}}" class="related-lookup" onclick="return showGenericRelatedObjectLookupPopup(this, {{ inline_admin_formset.formset.content_types }});" href="#">
-													<img width="16" height="16" alt="Lookup" src="{% admin_media_prefix %}img/admin/selector-search.gif"/>
+													<img width="16" height="16" alt="Lookup" src="{% static 'img/admin/selector-search.gif' %}"/>
 												</a>
 											{% else %}{{ field.field }} {% endifequal %}
 										{% endif %}


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.5/releases/1.5/#miscellaneous

Note: I've replace the use of `admin_media_prefix` with `staticfiles.static`, so it drops the Django 1.2 support out of the box. But I thought it was acceptable.

Thanks!

Yohan
