### PR TITLE
Use singleton `registry` to import `register_fk` and `register_m2m`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install -e .
   - pip install South
 script:
-  - ./example/manage.py test categories
+  - ./example/manage.py test categories --settings='settings-testing' 
 branches:
   only:
     - master

--- a/categories/__init__.py
+++ b/categories/__init__.py
@@ -23,10 +23,9 @@ default_app_config = 'categories.apps.CategoriesConfig'
 
 def register():
     from categories import settings
-    from categories.registration import (_process_registry, register_fk,
-                                        register_m2m)
-    _process_registry(settings.FK_REGISTRY, register_fk)
-    _process_registry(settings.M2M_REGISTRY, register_m2m)
+    from categories.registration import (_process_registry, registry)
+    _process_registry(settings.FK_REGISTRY, registry.register_fk)
+    _process_registry(settings.M2M_REGISTRY, registry.register_m2m)
 try:
     register()
 except Exception as e:

--- a/categories/tests/test_registration.py
+++ b/categories/tests/test_registration.py
@@ -51,7 +51,7 @@ class Categorym2mTest(TestCase):
         M2M_REGISTRY = {
             'flatpages.flatpage': 'categories'
         }
-        _process_registry(M2M_REGISTRY, register_m2m)
+        _process_registry(M2M_REGISTRY, registry.register_m2m)
         from django.contrib.flatpages.models import FlatPage
         self.assertTrue('category' in FlatPage()._meta.get_all_field_names())
 

--- a/example/settings-testing.py
+++ b/example/settings-testing.py
@@ -1,0 +1,89 @@
+# Django settings for sample project.
+import os
+import sys
+import django
+
+APP = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+PROJ_ROOT = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, APP)
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG
+
+ADMINS = (
+    # ('Your Name', 'your_email@domain.com'),
+)
+
+MANAGERS = ADMINS
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'dev.db',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django.contrib.flatpages',
+    'categories',
+    'categories.editor',
+    'mptt',
+    'simpletext',
+)
+
+TIME_ZONE = 'America/Chicago'
+
+LANGUAGE_CODE = 'en-us'
+
+SITE_ID = 1
+
+USE_I18N = True
+
+MEDIA_ROOT = os.path.abspath(os.path.join(PROJ_ROOT, 'media', 'uploads'))
+
+MEDIA_URL = '/uploads/'
+
+STATIC_ROOT = os.path.abspath(os.path.join(PROJ_ROOT, 'media', 'static'))
+
+STATIC_URL = '/static/'
+
+STATICFILES_DIRS = ()
+
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+)
+
+SECRET_KEY = 'bwq#m)-zsey-fs)0#4*o=2z(v5g!ei=zytl9t-1hesh4b&-u^d'
+
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
+
+ROOT_URLCONF = 'urls'
+
+TEMPLATE_DIRS = (
+    os.path.abspath(os.path.join(os.path.dirname(__file__), 'templates')),
+)
+
+if django.VERSION[1] > 5:
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'


### PR DESCRIPTION
Use singleton `registry` to import `register_fk` and `register_m2m` since they are members on `Registry` class. See #100 