### PR TITLE
ugettext may cause circular import

### DIFF
--- a/categories/base.py
+++ b/categories/base.py
@@ -7,7 +7,7 @@ from django.contrib import admin
 from django.db import models
 from django import forms
 from django.utils.encoding import force_unicode
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mptt.models import MPTTModel
 from mptt.fields import TreeForeignKey


### PR DESCRIPTION
Using the application [haystack](http://django-haystack.readthedocs.org/en/v2.4.0/), `ugettext` may cause a circular import this PR fix it.