### PR TITLE
Avoid the "Cannot call get_descendants on unsaved Category instances" ValueError

### DIFF
--- a/categories/base.py
+++ b/categories/base.py
@@ -108,10 +108,11 @@ class CategoryBaseAdminForm(forms.ModelForm):
         # Validate Category Parent
         # Make sure the category doesn't set itself or any of its children as
         # its parent.
-        decendant_ids = self.instance.get_descendants().values_list('id', flat=True)
+
         if self.cleaned_data.get('parent', None) is None or self.instance.id is None:
             return self.cleaned_data
-        elif self.cleaned_data['parent'].id == self.instance.id:
+        decendant_ids = self.instance.get_descendants().values_list('id', flat=True)
+        if self.cleaned_data['parent'].id == self.instance.id:
             raise forms.ValidationError(_("You can't set the parent of the "
                                           "item to itself."))
         elif self.cleaned_data['parent'].id in decendant_ids:

--- a/categories/editor/templatetags/admin_tree_list_tags.py
+++ b/categories/editor/templatetags/admin_tree_list_tags.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.template import Library
 from django.contrib.admin.templatetags.admin_list import result_headers, _boolean_icon
 try:
-    from django.contrib.admin.util import lookup_field, display_for_field, label_for_field
+    from django.contrib.admin.utils import lookup_field, display_for_field, label_for_field
 except ImportError:
     from categories.editor.utils import lookup_field, display_for_field, label_for_field
 from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE

--- a/categories/registration.py
+++ b/categories/registration.py
@@ -119,10 +119,10 @@ def _process_registry(registry, call_func):
     Given a dictionary, and a registration function, process the registry
     """
     from django.core.exceptions import ImproperlyConfigured
-    from django.db.models.loading import get_model
+    from django.apps import apps
 
     for key, value in registry.items():
-        model = get_model(*key.split('.'))
+        model = apps.get_model(*key.split('.'))
         if model is None:
             raise ImproperlyConfigured(_('%(key)s is not a model') % {'key': key})
         if isinstance(value, (tuple, list)):


### PR DESCRIPTION
When adding categories in admin interface.