### PR TITLE
Close table tag in templatetag result

### DIFF
--- a/categories/editor/templatetags/admin_tree_list_tags.py
+++ b/categories/editor/templatetags/admin_tree_list_tags.py
@@ -108,7 +108,7 @@ def items_for_tree_result(cl, result, form):
                 result_id = escapejs(value)
                 yield mark_safe(
                     format_html(
-                        '<{}{}><a href="{}"{}>{}</a><{}>',
+                        '<{}{}><a href="{}"{}>{}</a></{}>',
                         table_tag,
                         row_class,
                         url,


### PR DESCRIPTION
In items_for_tree_result, there's a format_html call which builds HTML via string interpolation. It missed back slash in the closing tag. This commit adds that.