### PR TITLE
Fix TypeError on changelist_view in django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+python:
+  - "3.5"
+
 branches:
   only:
     - master
@@ -15,6 +18,7 @@ env:
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django110
+  - TOXENV=py35-django111
 
 install:
   - pip install tox

--- a/categories/editor/tree_editor.py
+++ b/categories/editor/tree_editor.py
@@ -261,7 +261,7 @@ class TreeEditor(admin.ModelAdmin):
             'admin/%s/%s/change_list.html' % (app_label, opts.object_name.lower()),
             'admin/%s/change_list.html' % app_label,
             'admin/change_list.html'
-        ], context=context_instance)
+        ], context=context_instance.flatten())
 
     def changelist_view(self, request, extra_context=None, *args, **kwargs):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,11 @@ envlist =
     py27-lint
     py27-django{18,19,110},
     py34-django{18,19,110},
-    py35-django{18,19,110},
+    py35-django{18,19,110,111},
 
 [testenv]
 deps=
+    django111: Django==1.11.1
     django110: Django==1.10.3
     django19: Django==1.9.2
     django18: Django==1.8.9


### PR DESCRIPTION
List of categories view throws exception in django 1.11 admin. It happens because of changes in Django 1.11 (https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context. So, where is a small changes on redirect_response. RequestContext returned as flatten dict.

Also changes on tox.ini and travis.yml (lines 3-4, not sure it required, but tests didn't run without it with error "Interpreter not found: python 3.5")