### PR TITLE
Fix 'Models aren't loaded yet' warning on import

### DIFF
--- a/categories/__init__.py
+++ b/categories/__init__.py
@@ -21,16 +21,3 @@ __version__ = get_version()
 
 
 default_app_config = 'categories.apps.CategoriesConfig'
-
-
-def register():
-    from categories import settings
-    from categories.registration import (_process_registry, registry)
-    _process_registry(settings.FK_REGISTRY, registry.register_fk)
-    _process_registry(settings.M2M_REGISTRY, registry.register_m2m)
-
-
-try:
-    register()
-except Exception as e:
-    print(e)

--- a/categories/tests/test_mgmt_commands.py
+++ b/categories/tests/test_mgmt_commands.py
@@ -2,10 +2,21 @@
 
 from django.core import management
 from django.core.management.base import CommandError
+from django.db import connection
 from django.test import TestCase
 
 
 class TestMgmtCommands(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        connection.disable_constraint_checking()
+        super(TestMgmtCommands, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestMgmtCommands, cls).tearDownClass()
+        connection.enable_constraint_checking()
 
     def test_add_category_fields(self):
         management.call_command('add_category_fields', verbosity=0)


### PR DESCRIPTION
`categories.registration._process_registry` was being called in `categories/__init__.py`, but since Django 1.9 it hasn't been possible to perform operations with models until the app registry is fully loaded. Currently the `AppRegistryNotReady` exception is being caught and printed, but the `_process_registry` calls ought to be executed in the app's `AppConfig.ready`.