### PR TITLE
Add support for Django 3.1

### DIFF
--- a/categories/registration.py
+++ b/categories/registration.py
@@ -1,7 +1,8 @@
 """
 These functions handle the adding of fields to other models
 """
-from django.db.models import FieldDoesNotExist, ForeignKey, ManyToManyField, CASCADE
+from django.db.models import ForeignKey, ManyToManyField, CASCADE
+from django.core.exceptions import FieldDoesNotExist
 from . import fields
 # from settings import self._field_registry, self._model_registry
 from django.utils.translation import ugettext_lazy as _

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django-mptt>=0.9.0,<0.11
+django-mptt==0.11.0
 unicode-slugify==0.1.3


### PR DESCRIPTION
In Django 3.1

The compatibility import of `django.core.exceptions.FieldDoesNotExist` in `django.db.models.fields` is removed.

Replacing 
`from django.db.models.fields import FieldDoesNotExist`
with
`from django.core.exceptions import FieldDoesNotExist`
does the trick and the package works with Django 3.1.

Tested also with Django 3.0.8 and it works fine so there should be no backwards incompatibility.

Regarding requirements, django-mptt earlier versions have the same problem with `FieldDoesNotExist`. The issue is fixed in version 0.11.